### PR TITLE
Systematic tests

### DIFF
--- a/python/py_defines.h
+++ b/python/py_defines.h
@@ -50,4 +50,7 @@ http://www.opensource.apple.com/source/tcl/tcl-14/tcl/license.terms
 
 #define PyString_FromString     PyUnicode_FromString
 
+#define PyUnicode_AsUTF8String(o) \
+    (PyUnicode_AsEncodedString((o), "utf-8", "surrogatepass"))
+
 #endif

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -208,6 +208,13 @@ class UltraJSONTests(unittest.TestCase):
         self.assertEqual(enc, json_unicode(input))
         self.assertEqual(dec, json.loads(enc))
 
+    def test_encodeUnicodeBogusSurrogate(self):
+        input = u'"\udcff"'
+        enc = ujson.encode(input)
+        dec = ujson.decode(enc)
+        self.assertEqual(enc, json_unicode(input))
+        self.assertEqual(dec, json.loads(enc))
+
     def test_encodeUnicode4BytesUTF8(self):
         input = "\xf0\x91\x80\xb0TRAILINGNORMAL"
         enc = ujson.encode(input)
@@ -920,11 +927,6 @@ class UltraJSONTests(unittest.TestCase):
 
     def test_WriteArrayOfSymbolsFromTuple(self):
         self.assertEqual("[true,false,null]", ujson.dumps((True, False, None)))
-
-    @unittest.skipIf(not six.PY3, "Only raises on Python 3")
-    def test_encodingInvalidUnicodeCharacter(self):
-        s = "\udc7f"
-        self.assertRaises(UnicodeEncodeError, ujson.dumps, s)
 
     def test_sortKeys(self):
         data = {"a": 1, "c": 1, "b": 1, "e": 1, "f": 1, "d": 1}


### PR DESCRIPTION
(The actual changes here are a dummy to make a PR, because as a fork this doesn't have "issues".)

This project has a solid test suite that runs nice and fast -- under 0.5s on my laptop.

Here's a quick braindump of things that would amplify the value of the tests:
* Add a `tox.ini` or similar to make it easy to run them in different Python versions, without the overhead of getting a run from Travis. Here's what I have in my shell history:
```
$ deactivate; v=$(mktemp -d); time { virtualenv -p python3 "$v" && . "$v"/bin/activate && pip install six pytz unittest2 . && python tests/tests.py; }
```
* Factor out the common boilerplate in the many simple test cases like this one:
```
    def test_encodeControlEscaping(self):
        input = "\x19"
        enc = ujson.encode(input)
        dec = ujson.decode(enc)
        self.assertEqual(input, dec)
        self.assertEqual(enc, json_unicode(input))
```
  to make it super lightweight to add more.
* Copy test cases from simplejson -- e.g. [these](https://github.com/simplejson/simplejson/commit/5c18515a4a0e23cd0ee391200731c49ad4fbb631#diff-6baab796946edec66a315aad3142dfcd) for Unicode surrogate codepoints, since we just fixed a bug related to those.
